### PR TITLE
Can't auto update home screen when switch

### DIFF
--- a/src/components/organisms/Card.tsx
+++ b/src/components/organisms/Card.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { SFC } from 'react';
 import {
   Card,
   CardItem,
@@ -12,9 +12,11 @@ import {
 } from 'native-base';
 import { ItemModel } from '../../services/item/models';
 
-const CardComponent: FC<{
+interface CardComponentProps {
   item: ItemModel;
-}> = ({ item }) => {
+}
+
+const CardComponent: SFC<CardComponentProps> = ({ item }) => {
   return (
     <Card>
       <CardItem>

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { SFC } from 'react';
 import { Footer, FooterTab, Button, Icon, Text } from 'native-base';
 import {
   NavigationScreenProp,
@@ -6,10 +6,15 @@ import {
   NavigationParams,
 } from 'react-navigation';
 
-const FooterComponent: FC<{
+interface HeaderComponentProps {
   navigation: NavigationScreenProp<NavigationState, NavigationParams>;
   navigationIndex: number;
-}> = ({ navigation, navigationIndex = 0 }) => {
+}
+
+const FooterComponent: SFC<HeaderComponentProps> = ({
+  navigation,
+  navigationIndex = 0,
+}) => {
   return (
     <Footer>
       <FooterTab>

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -1,11 +1,13 @@
-import React, { FC, useState, useEffect } from 'react';
+import React, { SFC, useState, useEffect } from 'react';
 import * as Font from 'expo-font';
 import { Header, Left, Button, Icon, Title, Right, Body } from 'native-base';
 import { NavigationParams } from 'react-navigation';
 
-const HeaderComponent: FC<{
+interface HeaderComponentProps {
   navigation: NavigationParams;
-}> = ({ navigation }) => {
+}
+
+const HeaderComponent: SFC<HeaderComponentProps> = ({ navigation }) => {
   const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {

--- a/src/components/organisms/PostForm.tsx
+++ b/src/components/organisms/PostForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { SFC } from 'react';
 import {
   Field,
   reduxForm,
@@ -21,11 +21,17 @@ import {
 } from 'native-base';
 import { ItemModel } from '../../services/item/models';
 
-const renderInput: FC<{
+interface renderInputProps {
   input: TextInputProps;
   label: string;
   meta: FieldArrayMetaProps;
-}> = ({ input, label, meta: { error } }) => {
+}
+
+const renderInput: SFC<renderInputProps> = ({
+  input,
+  label,
+  meta: { error },
+}) => {
   let hasError = false;
   if (error !== undefined) {
     hasError = true;
@@ -40,7 +46,7 @@ const renderInput: FC<{
   );
 };
 
-const renderSelectField: React.FC<{ input: TextInputProps; label: string }> = ({
+const renderSelectField: React.SFC<renderInputProps> = ({
   input,
   label,
   children,
@@ -63,11 +69,7 @@ const renderSelectField: React.FC<{ input: TextInputProps; label: string }> = ({
   </>
 );
 
-const renderDateField: FC<{ input: TextInputProps; label: string }> = ({
-  input,
-  label,
-  children,
-}) => (
+const renderDateField: SFC<renderInputProps> = ({ input, label, children }) => (
   <>
     <Item>
       <DatePicker
@@ -93,7 +95,7 @@ interface ReduxFormExtendProps {
   submitFunction: (params: ItemModel) => void;
 }
 
-const PostForm: FC<
+const PostForm: SFC<
   InjectedFormProps<ItemModel, ReduxFormExtendProps> & ReduxFormExtendProps
 > = ({ submitFunction, handleSubmit }) => {
   return (

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -10,9 +10,11 @@ import {
   NavigationParams,
 } from 'react-navigation';
 
-const AccountScreen: FC<{
+interface AccountScreenProps {
   navigation: NavigationScreenProp<NavigationState, NavigationParams>;
-}> = ({ navigation }) => {
+}
+
+const AccountScreen: FC<AccountScreenProps> = ({ navigation }) => {
   return (
     <Container>
       <HeaderComponent navigation={navigation} />

--- a/src/screens/AddScreen.tsx
+++ b/src/screens/AddScreen.tsx
@@ -23,10 +23,12 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
     dispatch,
   );
 
-const AddScreen: FC<{
+interface AddScreenProps {
   postItemStart: (params: ItemModel) => void;
   navigation: NavigationParams;
-}> = ({ postItemStart, navigation }) => {
+}
+
+const AddScreen: FC<AddScreenProps> = ({ postItemStart, navigation }) => {
   const submit = (values: ItemModel) => {
     alert(`here is the value ${JSON.stringify(values)}`);
     postItemStart(values);

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -26,17 +26,34 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
     dispatch,
   );
 
-const HomeScreen: FC<{
+interface HomeScreenProps {
   items: ItemModel[];
   isLoading: boolean;
   fetchItemsStart: () => void;
   navigation: NavigationParams;
-}> = ({ items, isLoading, fetchItemsStart, navigation }) => {
+}
+
+const HomeScreen: FC<HomeScreenProps> = ({
+  items,
+  isLoading,
+  fetchItemsStart,
+  navigation,
+}) => {
   useEffect(() => {
     (async () => {
       await fetchItemsStart();
     })();
   }, []);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('willFocus', () => {
+      (async () => {
+        await fetchItemsStart();
+      })();
+    });
+
+    return unsubscribe;
+  }, [navigation]);
 
   return (
     <>

--- a/src/screens/SidebarScreen.tsx
+++ b/src/screens/SidebarScreen.tsx
@@ -8,9 +8,11 @@ import {
   NavigationParams,
 } from 'react-navigation';
 
-const SideBar: FC<{
+interface SideBarProps {
   navigation: NavigationScreenProp<NavigationState, NavigationParams>;
-}> = ({ navigation }) => {
+}
+
+const SideBar: FC<SideBarProps> = ({ navigation }) => {
   return (
     <Container>
       <Content>


### PR DESCRIPTION
## issue
https://github.com/stranger1989/merchandise_control_system_native_app/issues/2

## Refer followings
> https://reactnavigation.org/docs/4.x/navigation-prop

React-navigation can be listened focus or blur when screen has been changed.

```typescript
  useEffect(() => {
    const unsubscribe = navigation.addListener('willFocus', () => {
      (async () => {
        await fetchItemsStart();
      })();
    });

    return unsubscribe;
  }, [navigation]);
```

